### PR TITLE
Update Tetris mobile controls: hold to soft drop, pause button + two-finger tap

### DIFF
--- a/arcade/tetris/index.html
+++ b/arcade/tetris/index.html
@@ -42,6 +42,7 @@
         </svg>
       </a>
       <h1>Tetris</h1>
+      <button id="pause-btn" class="pause-btn mobile-only" aria-label="Pause game">| |</button>
     </header>
 
     <!-- Game Container -->
@@ -99,7 +100,7 @@
     <section class="controls-info">
       <small>
         <span class="desktop-only">Arrow keys to move | Up to rotate | Space to drop | C to hold | P to pause</span>
-        <span class="mobile-only">Swipe to move | Tap to rotate | Swipe down to drop | Swipe up or tap Hold to hold</span>
+        <span class="mobile-only">Swipe to move | Tap to rotate | Hold to soft drop | Swipe down to drop | Swipe up to hold | Two-finger tap or pause button to pause</span>
         <span class="music-toggle-wrapper">
           <button id="music-toggle" class="music-toggle" aria-label="Toggle music">♪</button>
         </span>

--- a/arcade/tetris/style.css
+++ b/arcade/tetris/style.css
@@ -301,6 +301,28 @@ html.darkmode .game-board .cell {
     color: var(--color-surface-primary);
 }
 
+/* Pause Button (mobile) */
+.pause-btn {
+    font-family: "GT Alpina Typewriter", Courier, monospace;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-content-primary);
+    background: transparent;
+    color: var(--color-content-primary);
+    cursor: crosshair;
+    transition: all 0.15s ease;
+    opacity: 0.5;
+    line-height: 1;
+    letter-spacing: -0.1em;
+    touch-action: manipulation;
+}
+
+.pause-btn:active {
+    opacity: 1;
+    background: var(--color-content-primary);
+    color: var(--color-surface-primary);
+}
+
 /* Line Clear Animation */
 @keyframes line-clear {
     0% { background-color: var(--color-content-primary); }

--- a/arcade/tetris/tetris.js
+++ b/arcade/tetris/tetris.js
@@ -721,20 +721,40 @@ function initTouchControls() {
     let touchStartX = 0;
     let touchStartY = 0;
     let touchStartTime = 0;
-    let lastTapTime = 0;
-    let longPressTimer = null;
+    let softDropTimer = null;
+    let softDropInterval = null;
     let lastMoveX = 0;
     let lastMoveY = 0;
     let gestureMoved = false;
+    let isSoftDropping = false;
     const SWIPE_THRESHOLD = 15;
     const TAP_THRESHOLD = 10;
-    const DOUBLE_TAP_DELAY = 300;
-    const LONG_PRESS_DELAY = 500;
+    const SOFT_DROP_DELAY = 200;
+    const SOFT_DROP_SPEED = 50;
 
     const gameArea = document.querySelector('.tetris-page');
 
+    function stopSoftDrop() {
+        if (softDropTimer) {
+            clearTimeout(softDropTimer);
+            softDropTimer = null;
+        }
+        if (softDropInterval) {
+            clearInterval(softDropInterval);
+            softDropInterval = null;
+        }
+        isSoftDropping = false;
+    }
+
     gameArea.addEventListener('touchstart', (e) => {
         if (gameState !== 'playing') return;
+
+        // Two-finger tap to pause
+        if (e.touches.length >= 2) {
+            stopSoftDrop();
+            pauseGame();
+            return;
+        }
 
         touchStartX = e.touches[0].clientX;
         touchStartY = e.touches[0].clientY;
@@ -743,20 +763,25 @@ function initTouchControls() {
         lastMoveY = touchStartY;
         gestureMoved = false;
 
-        // Start long press timer
-        longPressTimer = setTimeout(() => {
-            pauseGame();
-        }, LONG_PRESS_DELAY);
+        // Start soft drop after a short hold
+        softDropTimer = setTimeout(() => {
+            isSoftDropping = true;
+            softDrop();
+            softDropInterval = setInterval(() => {
+                if (gameState === 'playing') {
+                    softDrop();
+                } else {
+                    stopSoftDrop();
+                }
+            }, SOFT_DROP_SPEED);
+        }, SOFT_DROP_DELAY);
     }, { passive: true });
 
     gameArea.addEventListener('touchmove', (e) => {
         if (gameState !== 'playing') return;
 
-        // Cancel long press on move
-        if (longPressTimer) {
-            clearTimeout(longPressTimer);
-            longPressTimer = null;
-        }
+        // Cancel soft drop on move
+        stopSoftDrop();
 
         const touchX = e.touches[0].clientX;
         const touchY = e.touches[0].clientY;
@@ -780,11 +805,11 @@ function initTouchControls() {
     gameArea.addEventListener('touchend', (e) => {
         if (gameState !== 'playing') return;
 
-        // Cancel long press
-        if (longPressTimer) {
-            clearTimeout(longPressTimer);
-            longPressTimer = null;
-        }
+        const wasSoftDropping = isSoftDropping;
+        stopSoftDrop();
+
+        // If we were soft dropping, don't process as another gesture
+        if (wasSoftDropping) return;
 
         if (gestureMoved) {
             gestureMoved = false;
@@ -832,6 +857,19 @@ function initTouchControls() {
             e.preventDefault();
         }
     }, { passive: false });
+
+    // Mobile pause button
+    const pauseBtn = document.getElementById('pause-btn');
+    if (pauseBtn) {
+        pauseBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (gameState === 'playing') {
+                pauseGame();
+            } else if (gameState === 'paused') {
+                resumeGame();
+            }
+        });
+    }
 }
 
 // ============================================


### PR DESCRIPTION
Replace long-press pause with continuous soft drop — holding finger on
the game canvas now accelerates the piece downward. Add two alternative
pause methods for mobile: a dedicated pause button in the header and
a two-finger tap gesture. Update mobile controls help text accordingly.

https://claude.ai/code/session_0189zJ5DmfGLh58xtXwKGzcN