### PR TITLE
Add Library submenus on desktop + unify case study card visuals

### DIFF
--- a/style-v2.css
+++ b/style-v2.css
@@ -335,6 +335,7 @@ html.darkmode .sidebar-open-tab { color: var(--ink); }
     opacity: 0.6;
 }
 
+/* Mobile / tablet: absolute dropdown below the nav item */
 .resources-flyout {
     position: absolute;
     left: 100%;
@@ -357,6 +358,31 @@ html.darkmode .sidebar-open-tab { color: var(--ink); }
     transform: translateX(0);
 }
 
+/* Desktop: in-sidebar submenu — expands in-place below Library.
+   Sidebar has overflow:hidden which clips the left:100% flyout. */
+@media (min-width: 1025px) {
+    .resources-flyout {
+        position: static;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        pointer-events: none;
+        transform: none;
+        border: none;
+        border-top: var(--border-width) solid var(--line-color);
+        min-width: auto;
+        background: transparent;
+        transition: max-height 0.25s ease, opacity 0.2s ease;
+    }
+
+    .nav-resources:hover .resources-flyout {
+        max-height: 200px;
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
+    }
+}
+
 .flyout-link {
     padding: 0.85rem 1.5rem;
     text-decoration: none;
@@ -375,6 +401,19 @@ html.darkmode .sidebar-open-tab { color: var(--ink); }
 
 .flyout-link:hover {
     background: white;
+}
+
+/* Desktop flyout links: indent to show hierarchy */
+@media (min-width: 1025px) {
+    .flyout-link {
+        padding-left: 2rem;
+        font-size: 0.88rem;
+        opacity: 0.85;
+        border-bottom: var(--border-width) solid var(--line-color);
+    }
+    .flyout-link:last-child {
+        border-bottom: none;
+    }
 }
 
 /* Footer contact link */
@@ -685,7 +724,7 @@ h1 {
     background-position: center;
     z-index: 0;
     filter: grayscale(100%) contrast(110%);
-    transition: filter 0.4s ease;
+    transition: filter 0.4s ease, box-shadow 0.4s ease;
 }
 
 .cs-tiffany .cs-image {
@@ -694,19 +733,32 @@ h1 {
 }
 
 .cs-apple .cs-image {
-    background-image: url('/assets/cs02-bg.jpg');
+    background-image: url('https://images.unsplash.com/photo-1526374965328-7f61d4dc18c5?q=80&w=2560&auto=format&fit=crop');
     background-position: center center;
-    box-shadow: inset 0 0 0 2000px rgba(20, 30, 40, 0.55);
+    box-shadow: inset 0 0 0 2000px rgba(43, 58, 74, 0.7);
 }
 
 .cs-wc .cs-image {
-    background-image: url('/assets/cs03-bg.jpg');
+    background-image: url('https://images.unsplash.com/photo-1481487196290-c152efe083f5?q=80&w=2562&auto=format&fit=crop');
     background-position: center center;
-    box-shadow: inset 0 0 0 2000px rgba(120, 100, 90, 0.45);
+    box-shadow: inset 0 0 0 2000px rgba(43, 58, 74, 0.7);
 }
 
 .case-study:hover .cs-image {
     filter: grayscale(0%) contrast(100%);
+}
+
+/* Desktop: distinct hover accent colors per card */
+@media (min-width: 1025px) {
+    .cs-tiffany:hover .cs-image {
+        box-shadow: inset 0 0 0 2000px rgba(43, 58, 74, 0.45);
+    }
+    .cs-apple:hover .cs-image {
+        box-shadow: inset 0 0 0 2000px rgba(160, 75, 20, 0.45);
+    }
+    .cs-wc:hover .cs-image {
+        box-shadow: inset 0 0 0 2000px rgba(50, 20, 100, 0.45);
+    }
 }
 
 .cs-spine-text {


### PR DESCRIPTION
## Summary

- **Library submenus**: Fixed Knowledge/Prompts submenus not showing on desktop — sidebar `overflow:hidden` was clipping the `left:100%` flyout. Now uses an in-sidebar `max-height` dropdown on ≥1025px; mobile keeps the existing absolute drop-down behavior. Submenu links are indented (2rem) to show hierarchy.
- **Case study cards 02 & 03**: Replaced local assets with Unsplash images, matched Onyx's `rgba(43,58,74,0.7)` dark overlay so all three cards look identical in the default grayscale state, and added smooth per-card hover accent colors on desktop: Onyx = teal, Moments Collective = amber/copper, Studio 11 = indigo/purple.

## Test plan

- [ ] On desktop (≥1025px), hover Library nav item — Knowledge and Prompts links should expand in-place below it
- [ ] On mobile (≤1024px), Library flyout should still drop down below the nav tab
- [ ] All three case study cards should look visually identical in default (grayscale) state
- [ ] Hover each card on desktop: Onyx shows teal, card 02 shows amber, card 03 shows indigo

https://claude.ai/code/session_0176mGTnPy7KCrBwH9kVBVHP