### PR TITLE
Replace blog "Read →" link with "Coming soon" placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                     <a href="#work" class="mobile-menu-item" data-close>Work</a>
                     <a href="#about" class="mobile-menu-item" data-close>About</a>
                     <a href="https://www.llmxai.co/arcade/" class="mobile-menu-item">Arcade</a>
-                    <a href="/blog/" class="mobile-menu-item">Blog</a>
+                    <span class="mobile-menu-item" style="opacity: 0.4; cursor: default;">Blog (coming soon)</span>
                     <span class="mobile-menu-item" style="opacity: 0.4; cursor: default;">Bootcamp (coming soon)</span>
                     <a href="https://www.llmxai.co/prompts/" class="mobile-menu-item">Prompts</a>
                     <a href="https://www.llmxai.co/knowledge/" class="mobile-menu-item">Knowledge</a>
@@ -254,7 +254,7 @@
                     <h3>Blog</h3>
                     <p>Field notes from inside the work. Opinions on models, workflows, and what the AI discourse gets wrong. Written when there's something real to say — not on a schedule.</p>
                     <p style="margin-top: 1.5rem;">
-                        <a href="/blog/" style="font-family: var(--font-mono); font-size: 0.8rem; color: var(--paper-bg); opacity: 0.6; text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.3); padding-bottom: 2px;">Read →</a>
+                        <span style="font-family: var(--font-mono); font-size: 0.8rem; color: var(--paper-bg); opacity: 0.6;">Coming soon</span>
                     </p>
                 </div>
                 <div class="goods-card">


### PR DESCRIPTION
Temporarily disables blog access on prod by replacing the "Read →" link and mobile menu item with "Coming soon" — matching the existing Bootcamp treatment.